### PR TITLE
Add default ssh config

### DIFF
--- a/.ssh/.gitignore
+++ b/.ssh/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this dir
-*
-# Except .gitignore, of course
-!.gitignore

--- a/.ssh/config
+++ b/.ssh/config
@@ -1,0 +1,5 @@
+Host                    *
+BatchMode               yes
+IdentityFile            ~/.ssh/id_ecdsa
+StrictHostKeyChecking   no
+


### PR DESCRIPTION
Missed this bit during the migration.  `BatchMode yes` and `StrictHostKeyChecking no` allow `known_hosts` to be updated without user interaction.  Without, authentication confusingly fails with the same error message as if the keys were setup incorrectly.